### PR TITLE
fixing cwd bug

### DIFF
--- a/lib/gulp-galen.js
+++ b/lib/gulp-galen.js
@@ -117,14 +117,14 @@ var GulpEventStream = function (mode, specialOptionKeys) {
 
         return through.obj(function (file, encoding, callback) {
             var stream = this;
-            cwd = cwd || path.dirname(file.path);
+            var currentCwd = cwd || path.dirname(file.path);
             runGalen(this, function (error, file) {
                 if (error) {
                     callback(stream, error, file);
                 } else {
                     callback();
                 }
-            }, galenPath, mode, file, cwd, opt, properties);
+            }, galenPath, mode, file, currentCwd, opt, properties);
         });
     };
 };


### PR DESCRIPTION
my last commit brought a bug into the cwd configuration, causing the default cwd not being set to the current test's dir, when another test in another dir has been run before. sorry for that. this commit fixes the bug.